### PR TITLE
Add web interface for managing press dossiers

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,13 @@
-No me mires todavia
+# Gestor de Dossieres de Prensa
+
+Aplicación web estática para construir dossieres de prensa a partir de periódicos en PDF almacenados de forma local.
+
+## Cómo utilizarla
+1. Abre `index.html` en tu navegador.
+2. Usa el botón "Subir periódicos (PDF)" para cargar los archivos locales que quieras utilizar. Los PDFs solo se procesan en tu navegador.
+3. Selecciona un periódico para ver todas sus páginas. Pulsa "Añadir al dossier" en las páginas que quieras incorporar.
+4. En el panel derecho elige un dossier existente (Política, Deportes, Economía) o crea uno nuevo. Cada dossier incluye una portada fija.
+5. Reordena las páginas arrastrándolas y suéltalas en la posición deseada.
+6. Añade marcas a cada página con el botón "Añadir marca". Las marcas aparecen como chips y pueden eliminarse desde el propio dossier.
+
+> Consejo: al tratarse de una aplicación estática, todos los datos se mantienen únicamente durante la sesión actual del navegador.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,453 @@
+const pdfInput = document.getElementById('pdf-input');
+const documentList = document.getElementById('document-list');
+const documentViewer = document.getElementById('document-viewer');
+const dossierList = document.getElementById('dossier-list');
+const dossierViewer = document.getElementById('dossier-viewer');
+const newDossierForm = document.getElementById('new-dossier-form');
+const newDossierName = document.getElementById('new-dossier-name');
+const pageTemplate = document.getElementById('page-template');
+const markerModal = document.getElementById('marker-modal');
+const markerTextarea = document.getElementById('marker-text');
+const markerCancelButton = document.getElementById('marker-cancel');
+const markerSaveButton = document.getElementById('marker-save');
+
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+
+const state = {
+  documents: new Map(),
+  dossiers: new Map(),
+  selectedDocumentId: null,
+  selectedDossierId: null,
+  markerTarget: null,
+};
+
+function uid(prefix) {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function createCoverPage(name) {
+  return {
+    id: uid('cover'),
+    type: 'cover',
+    title: name,
+  };
+}
+
+function createDossier(name) {
+  const id = uid('dossier');
+  const dossier = {
+    id,
+    name,
+    pages: [createCoverPage(name)],
+  };
+  state.dossiers.set(id, dossier);
+  return dossier;
+}
+
+function ensureInitialDossiers() {
+  const defaults = ['Política', 'Deportes', 'Economía'];
+  defaults.forEach((name) => createDossier(name));
+}
+
+function renderDocumentList() {
+  documentList.innerHTML = '';
+  if (!state.documents.size) {
+    const empty = document.createElement('p');
+    empty.className = 'placeholder';
+    empty.textContent = 'Sube tus periódicos en PDF para comenzar a crear dossieres.';
+    documentList.appendChild(empty);
+    return;
+  }
+
+  for (const doc of state.documents.values()) {
+    const button = document.createElement('button');
+    button.className = 'document-item';
+    button.dataset.id = doc.id;
+    button.innerHTML = `<span class="document-item__name">${doc.name}</span><span>${doc.pageCount || ''}</span>`;
+    if (doc.id === state.selectedDocumentId) {
+      button.classList.add('active');
+    }
+    button.addEventListener('click', () => {
+      state.selectedDocumentId = doc.id;
+      renderDocumentList();
+      renderDocumentPages(doc.id);
+    });
+    documentList.appendChild(button);
+  }
+}
+
+async function renderDocumentPages(documentId) {
+  const doc = state.documents.get(documentId);
+  if (!doc) return;
+
+  documentViewer.innerHTML = '';
+  const grid = document.createElement('div');
+  grid.className = 'page-grid';
+  documentViewer.appendChild(grid);
+
+  const pdf = await doc.pdfPromise;
+  doc.pageCount = pdf.numPages;
+  renderDocumentList();
+
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+    const page = await pdf.getPage(pageNumber);
+    const card = createPageCard({
+      title: `Página ${pageNumber}`,
+      pageNumber,
+      actions: [
+        {
+          label: 'Añadir al dossier',
+          handler: () => addPageToDossier(doc.id, pageNumber),
+        },
+      ],
+      footer: [`${doc.name}`],
+    });
+
+    const canvasWrapper = card.querySelector('.page-card__canvas-wrapper');
+    const canvas = document.createElement('canvas');
+    canvasWrapper.appendChild(canvas);
+    await renderPdfPageToCanvas(page, canvas, 0.45);
+
+    grid.appendChild(card);
+  }
+}
+
+function createPageCard({ title, actions = [], footer = [] }) {
+  const card = pageTemplate.content.firstElementChild.cloneNode(true);
+  const titleEl = card.querySelector('.page-card__title');
+  const actionsContainer = card.querySelector('.page-card__actions');
+  const footerEl = card.querySelector('.page-card__footer');
+
+  titleEl.textContent = title;
+  actionsContainer.innerHTML = '';
+  footerEl.innerHTML = '';
+
+  actions.forEach(({ label, handler, disabled }) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.disabled = Boolean(disabled);
+    button.addEventListener('click', handler);
+    actionsContainer.appendChild(button);
+  });
+
+  footer.forEach((item) => {
+    if (typeof item === 'string') {
+      const span = document.createElement('span');
+      span.textContent = item;
+      footerEl.appendChild(span);
+    } else if (item instanceof HTMLElement) {
+      footerEl.appendChild(item);
+    }
+  });
+
+  return card;
+}
+
+async function renderPdfPageToCanvas(page, canvas, scale = 0.35) {
+  const viewport = page.getViewport({ scale });
+  const context = canvas.getContext('2d');
+  canvas.height = viewport.height;
+  canvas.width = viewport.width;
+  await page.render({ canvasContext: context, viewport }).promise;
+}
+
+function renderDossierList() {
+  dossierList.innerHTML = '';
+  for (const dossier of state.dossiers.values()) {
+    const button = document.createElement('button');
+    button.className = 'dossier-item';
+    button.dataset.id = dossier.id;
+    button.innerHTML = `<span class="dossier-item__name">${dossier.name}</span><span>${dossier.pages.length - 1}</span>`;
+    if (dossier.id === state.selectedDossierId) {
+      button.classList.add('active');
+    }
+    button.addEventListener('click', () => {
+      state.selectedDossierId = dossier.id;
+      renderDossierList();
+      renderDossier(dossier.id);
+    });
+    dossierList.appendChild(button);
+  }
+}
+
+async function renderDossier(dossierId) {
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+
+  dossierViewer.innerHTML = '';
+  const grid = document.createElement('div');
+  grid.className = 'page-grid';
+  grid.dataset.dossierId = dossierId;
+  dossierViewer.appendChild(grid);
+
+  for (const pageData of dossier.pages) {
+    let card;
+
+    if (pageData.type === 'cover') {
+      card = createPageCard({
+        title: 'Portada',
+        actions: [],
+        footer: [`${dossier.name}`],
+      });
+      card.classList.add('cover-card');
+      card.draggable = false;
+      const wrapper = card.querySelector('.page-card__canvas-wrapper');
+      wrapper.innerHTML = '';
+      const cover = document.createElement('div');
+      cover.className = 'cover-page';
+      cover.innerHTML = `<h3>${dossier.name.toUpperCase()}</h3><p>Dossier de prensa</p>`;
+      wrapper.appendChild(cover);
+    } else {
+      const doc = state.documents.get(pageData.documentId);
+      const actions = [
+        {
+          label: 'Eliminar',
+          handler: () => removePageFromDossier(dossierId, pageData.id),
+        },
+        {
+          label: 'Añadir marca',
+          handler: () => openMarkerModal(dossierId, pageData.id),
+        },
+      ];
+
+      card = createPageCard({
+        title: `${doc ? doc.name : 'Periódico'} · Página ${pageData.pageNumber}`,
+        actions,
+        footer: buildMarkersFooter(pageData),
+      });
+
+      attachDragEvents(card, dossierId, pageData.id);
+
+      const wrapper = card.querySelector('.page-card__canvas-wrapper');
+      wrapper.innerHTML = '';
+
+      if (doc) {
+        const pdf = await doc.pdfPromise;
+        const page = await pdf.getPage(pageData.pageNumber);
+        const canvas = document.createElement('canvas');
+        wrapper.appendChild(canvas);
+        await renderPdfPageToCanvas(page, canvas, 0.45);
+      } else {
+        wrapper.innerHTML = '<p class="placeholder">Documento no disponible</p>';
+      }
+    }
+
+    grid.appendChild(card);
+  }
+
+  grid.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    const afterElement = getDragAfterElement(grid, event.clientY);
+    const dragging = grid.querySelector('.dragging');
+    if (!dragging) return;
+    if (afterElement == null) {
+      grid.appendChild(dragging);
+    } else {
+      grid.insertBefore(dragging, afterElement);
+    }
+  });
+
+  grid.addEventListener('drop', () => {
+    const order = Array.from(grid.children)
+      .map((cardEl) => cardEl.dataset.pageId)
+      .filter(Boolean);
+    reorderDossierPages(dossierId, order);
+  });
+}
+
+function buildMarkersFooter(pageData) {
+  if (!pageData.markers || !pageData.markers.length) {
+    return ['Sin marcas'];
+  }
+  const items = ['Marcas:'];
+  pageData.markers.forEach((marker) => {
+    const chip = document.createElement('span');
+    chip.className = 'marker-chip';
+    chip.textContent = marker.text;
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.textContent = '×';
+    removeButton.dataset.markerId = marker.id;
+    chip.appendChild(removeButton);
+
+    items.push(chip);
+  });
+  return items;
+}
+
+function attachDragEvents(card, dossierId, pageId) {
+  card.dataset.pageId = pageId;
+  card.addEventListener('dragstart', () => {
+    card.classList.add('dragging');
+  });
+  card.addEventListener('dragend', () => {
+    card.classList.remove('dragging');
+  });
+}
+
+function getDragAfterElement(container, y) {
+  const draggableElements = [...container.querySelectorAll('.page-card[draggable="true"]:not(.dragging)')];
+
+  return draggableElements.reduce(
+    (closest, child) => {
+      const box = child.getBoundingClientRect();
+      const offset = y - (box.top + box.height / 2);
+      if (offset < 0 && offset > closest.offset) {
+        return { offset, element: child };
+      }
+      return closest;
+    },
+    { offset: Number.NEGATIVE_INFINITY, element: null },
+  ).element;
+}
+
+function addPageToDossier(documentId, pageNumber) {
+  if (!state.selectedDossierId) {
+    alert('Selecciona un dossier en el panel derecho antes de añadir páginas.');
+    return;
+  }
+
+  const dossier = state.dossiers.get(state.selectedDossierId);
+  if (!dossier) return;
+
+  const pageData = {
+    id: uid('page'),
+    type: 'page',
+    documentId,
+    pageNumber,
+    markers: [],
+  };
+
+  dossier.pages.push(pageData);
+  renderDossier(state.selectedDossierId);
+  renderDossierList();
+}
+
+function removePageFromDossier(dossierId, pageId) {
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+  dossier.pages = dossier.pages.filter((page) => page.id !== pageId || page.type === 'cover');
+  renderDossier(dossierId);
+  renderDossierList();
+}
+
+function reorderDossierPages(dossierId, orderedIds) {
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+  const cover = dossier.pages.find((page) => page.type === 'cover');
+  const otherPages = dossier.pages.filter((page) => page.type !== 'cover');
+  const idToPage = new Map(otherPages.map((page) => [page.id, page]));
+  const reordered = orderedIds.map((id) => idToPage.get(id)).filter(Boolean);
+  dossier.pages = [cover, ...reordered];
+  renderDossier(dossierId);
+  renderDossierList();
+}
+
+function openMarkerModal(dossierId, pageId) {
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+  const page = dossier.pages.find((p) => p.id === pageId);
+  if (!page) return;
+  state.markerTarget = { dossierId, pageId };
+  markerTextarea.value = '';
+  markerModal.classList.remove('hidden');
+  markerTextarea.focus();
+}
+
+function closeMarkerModal() {
+  state.markerTarget = null;
+  markerTextarea.value = '';
+  markerModal.classList.add('hidden');
+}
+
+function saveMarker() {
+  const text = markerTextarea.value.trim();
+  if (!text || !state.markerTarget) {
+    closeMarkerModal();
+    return;
+  }
+  const { dossierId, pageId } = state.markerTarget;
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+  const page = dossier.pages.find((p) => p.id === pageId);
+  if (!page) return;
+  page.markers.push({ id: uid('marker'), text });
+  closeMarkerModal();
+  renderDossier(dossierId);
+}
+
+function removeMarker(dossierId, pageId, markerId) {
+  const dossier = state.dossiers.get(dossierId);
+  if (!dossier) return;
+  const page = dossier.pages.find((p) => p.id === pageId);
+  if (!page) return;
+  page.markers = page.markers.filter((marker) => marker.id !== markerId);
+  renderDossier(dossierId);
+}
+
+function handleDocumentUpload(event) {
+  const files = Array.from(event.target.files || []);
+  files.forEach((file) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const buffer = reader.result;
+      const id = uid('doc');
+      const pdfPromise = pdfjsLib.getDocument({ data: buffer }).promise;
+      state.documents.set(id, {
+        id,
+        name: file.name.replace(/\.pdf$/i, ''),
+        buffer,
+        pdfPromise,
+        pageCount: null,
+      });
+      renderDocumentList();
+    };
+    reader.readAsArrayBuffer(file);
+  });
+
+  event.target.value = '';
+}
+
+function handleNewDossier(event) {
+  event.preventDefault();
+  const name = newDossierName.value.trim();
+  if (!name) return;
+  const dossier = createDossier(name);
+  state.selectedDossierId = dossier.id;
+  newDossierName.value = '';
+  renderDossierList();
+  renderDossier(dossier.id);
+}
+
+function init() {
+  ensureInitialDossiers();
+  renderDocumentList();
+  renderDossierList();
+
+  pdfInput.addEventListener('change', handleDocumentUpload);
+  newDossierForm.addEventListener('submit', handleNewDossier);
+  markerCancelButton.addEventListener('click', closeMarkerModal);
+  markerSaveButton.addEventListener('click', saveMarker);
+  markerModal.addEventListener('click', (event) => {
+    if (event.target === markerModal) {
+      closeMarkerModal();
+    }
+  });
+
+  dossierViewer.addEventListener('click', (event) => {
+    const markerButton = event.target.closest('.marker-chip button');
+    if (!markerButton) return;
+    event.preventDefault();
+    const card = event.target.closest('.page-card');
+    if (!card) return;
+    const pageId = card.dataset.pageId;
+    const markerId = markerButton.dataset.markerId;
+    if (!pageId || !markerId) return;
+    removeMarker(state.selectedDossierId, pageId, markerId);
+  });
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gestor de Dossieres de Prensa</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha512-ZSjK8mFsNyZwyKwkGGlN63oqUS5xK14H+QCjuC5E4TLZsXBLzGZs2y3eyZp4OhJ5maPkqlqbm0o7ILo7Zo/seg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+  <header>
+    <h1>Gestor de Dossieres de Prensa</h1>
+    <p>Organiza las páginas de tus periódicos en dossieres temáticos con total libertad.</p>
+  </header>
+  <main>
+    <section class="panel" id="library-panel">
+      <div class="panel-header">
+        <h2>Hemeroteca</h2>
+        <label class="file-upload">
+          <input type="file" id="pdf-input" accept="application/pdf" multiple />
+          <span>Subir periódicos (PDF)</span>
+        </label>
+      </div>
+      <div class="library">
+        <aside class="document-list" id="document-list"></aside>
+        <div class="document-viewer" id="document-viewer">
+          <p class="placeholder">Selecciona un periódico para ver sus páginas.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" id="dossier-panel">
+      <div class="panel-header">
+        <div>
+          <h2>Dossieres</h2>
+          <p class="help-text">Selecciona un dossier para editarlo, reordenar páginas y añadir marcas.</p>
+        </div>
+        <form id="new-dossier-form" class="new-dossier-form">
+          <input type="text" id="new-dossier-name" placeholder="Nuevo dossier" aria-label="Nombre del nuevo dossier" />
+          <button type="submit">Crear</button>
+        </form>
+      </div>
+      <div class="dossier-container">
+        <aside class="dossier-list" id="dossier-list"></aside>
+        <div class="dossier-viewer" id="dossier-viewer">
+          <p class="placeholder">Elige un dossier para empezar a construir tu dossier de prensa.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <template id="page-template">
+    <article class="page-card" draggable="true">
+      <header class="page-card__header">
+        <span class="page-card__title"></span>
+        <div class="page-card__actions"></div>
+      </header>
+      <div class="page-card__canvas-wrapper"></div>
+      <footer class="page-card__footer"></footer>
+    </article>
+  </template>
+
+  <div class="modal hidden" id="marker-modal" role="dialog" aria-modal="true" aria-labelledby="marker-modal-title">
+    <div class="modal__content">
+      <h3 id="marker-modal-title">Añadir marca</h3>
+      <label class="modal__label" for="marker-text">Texto de la marca</label>
+      <textarea id="marker-text" rows="3"></textarea>
+      <div class="modal__actions">
+        <button type="button" id="marker-cancel">Cancelar</button>
+        <button type="button" id="marker-save">Guardar</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,388 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fa;
+  --panel-bg: #ffffffcc;
+  --border: #d9dfe7;
+  --primary: #184d8a;
+  --accent: #d97706;
+  --text: #1a1f29;
+  --muted: #6c7280;
+  --radius: 14px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #eef2f7 0%, #ffffff 60%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 1.5rem 4vw 0.5rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.5vw, 2.6rem);
+}
+
+header p {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+}
+
+main {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem 4vw 3rem;
+  flex: 1;
+}
+
+.panel {
+  background: var(--panel-bg);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 18px 40px -25px rgba(24, 77, 138, 0.35);
+}
+
+.panel-header {
+  padding: 1.2rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.help-text {
+  color: var(--muted);
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+}
+
+.library,
+.dossier-container {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.document-list,
+.dossier-list {
+  width: 230px;
+  border-right: 1px solid var(--border);
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.document-viewer,
+.dossier-viewer {
+  flex: 1;
+  padding: 1.25rem;
+  overflow-y: auto;
+  position: relative;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--muted);
+  text-align: center;
+  padding: 2rem;
+}
+
+.file-upload {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.file-upload input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+}
+
+.button,
+button,
+.document-item,
+.dossier-item {
+  border: none;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.document-item,
+.dossier-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(24, 77, 138, 0.08);
+  color: var(--primary);
+}
+
+.document-item:hover,
+.dossier-item:hover,
+.document-item.active,
+.dossier-item.active {
+  background: rgba(24, 77, 138, 0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px -15px rgba(24, 77, 138, 0.6);
+}
+
+.document-item__name,
+.dossier-item__name {
+  flex: 1;
+  text-align: left;
+}
+
+.page-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.1rem;
+}
+
+.page-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 18px 40px -30px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.page-card.dragging {
+  opacity: 0.3;
+}
+
+.page-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.page-card__title {
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.page-card__actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.page-card__actions button {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(24, 77, 138, 0.12);
+  color: var(--primary);
+}
+
+.page-card__actions button:hover {
+  background: rgba(24, 77, 138, 0.22);
+}
+
+.page-card__canvas-wrapper {
+  position: relative;
+  border: 1px solid rgba(24, 77, 138, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+  background: repeating-linear-gradient(45deg, rgba(24, 77, 138, 0.05), rgba(24, 77, 138, 0.05) 10px, transparent 10px, transparent 20px);
+  min-height: 280px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-card canvas {
+  width: 100%;
+  height: auto;
+}
+
+.page-card__footer {
+  font-size: 0.8rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.marker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(217, 119, 6, 0.18);
+  color: var(--accent);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.marker-chip button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.9rem;
+}
+
+.cover-page {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  min-height: 280px;
+  background: radial-gradient(circle at top, rgba(24, 77, 138, 0.18), rgba(24, 77, 138, 0.65));
+  color: #fff;
+}
+
+.cover-page h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: 0.12em;
+}
+
+.new-dossier-form {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.new-dossier-form input {
+  padding: 0.5rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  min-width: 160px;
+}
+
+.new-dossier-form button {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.4);
+  display: grid;
+  place-items: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal__content {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: min(360px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.modal__label {
+  font-weight: 600;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.modal__actions button {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+}
+
+#marker-save {
+  background: var(--accent);
+  color: #fff;
+}
+
+#marker-cancel {
+  background: rgba(24, 77, 138, 0.1);
+  color: var(--primary);
+}
+
+@media (max-width: 1100px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .document-list,
+  .dossier-list {
+    width: 200px;
+  }
+}
+
+@media (max-width: 780px) {
+  header {
+    padding: 1.2rem 1.5rem 0;
+  }
+
+  main {
+    padding: 1.2rem 1.5rem 2.5rem;
+  }
+
+  .document-list,
+  .dossier-list {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  .library,
+  .dossier-container {
+    flex-direction: column;
+  }
+
+  .document-viewer,
+  .dossier-viewer {
+    padding: 1rem 1rem 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a static single-page app to cargar periódicos en PDF y previsualizar cada página
- enable creation and editing of press dossiers with drag-and-drop ordering and marker annotations
- polish the interface styling and document how to use the tool

## Testing
- Manual QA

------
https://chatgpt.com/codex/tasks/task_e_68e508ff566c832c944673e34502625e